### PR TITLE
fix: use single quotes for string in expression

### DIFF
--- a/.github/workflows/frontend:erc20-messaging.yml
+++ b/.github/workflows/frontend:erc20-messaging.yml
@@ -62,7 +62,7 @@ jobs:
           TOPOS_CORE_PROXY_SALT: ${{ secrets.TOPOS_CORE_PROXY_SALT }}
           ERC20_MESSAGING_SALT: ${{ secrets.ERC20_MESSAGING_SALT }}
           SUBNET_REGISTRATOR_SALT: ${{ secrets.SUBNET_REGISTRATOR_SALT }}
-          TOPOS_MESSAGING_PROTOCOL_CONTRACTS_VERSION: ${{ inputs.topos-smart-contracts-docker-tag || "latest" }}
+          TOPOS_MESSAGING_PROTOCOL_CONTRACTS_VERSION: ${{ inputs.topos-smart-contracts-docker-tag || 'latest' }}
 
       - name: Debug containers
         if: failure()


### PR DESCRIPTION
# Description

This PR replaces double quotes with single ones for string in github action expressions.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
