### PR TITLE
ci (sequencer-contracts): use github token to prevent rate limiting

### DIFF
--- a/.github/workflows/topos:sequencer-contracts.yml
+++ b/.github/workflows/topos:sequencer-contracts.yml
@@ -82,7 +82,9 @@ jobs:
         uses: Swatinem/rust-cache@v1
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull polygon-edge docker image
         run: |


### PR DESCRIPTION
# Description

This PR makes use of github's token to prevent rate limiting at the step of setting up protoc (sequencer-contracts tests).

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
