### PR TITLE
fix: add missing topos docker tag print

### DIFF
--- a/.github/workflows/frontend:erc20-messaging.yml
+++ b/.github/workflows/frontend:erc20-messaging.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           echo "infra ref: ${{ env.INFRA_REF }}"
           echo "frontend ref: ${{ env.FRONTEND_REF }}"
+          echo "topos docker tag: ${{ env.TOPOS_DOCKER_TAG }}"
           echo "contracts docker tag: ${{ env.CONTRACTS_DOCKER_TAG }}"
           echo "executor service docker tag: ${{ env.EXECUTOR_SERVICE_DOCKER_TAG }}"
 


### PR DESCRIPTION
# Description

This PR adds the missing docker tag print for `topos`.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
