### PR TITLE
fix: remove edena

### DIFF
--- a/.github/workflows/frontend:erc20-messaging.yml
+++ b/.github/workflows/frontend:erc20-messaging.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Debug containers
         if: failure()
-        run: docker inspect contracts-edena | grep Image && docker logs contracts-edena
+        run: docker inspect contracts-topos | grep Image && docker logs contracts-topos
 
       - name: Get contracts .env file and expose contract addresses for frontend
         run: |


### PR DESCRIPTION
# Description

This PR removes the use of Edena's containers to reflect Edena's removal of the local-erc20-messaging-infra stack.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
