### PR TITLE
feat: use latest docker image for topos

### DIFF
--- a/.github/workflows/frontend:erc20-messaging.yml
+++ b/.github/workflows/frontend:erc20-messaging.yml
@@ -23,7 +23,7 @@ on:
         required: false
 
 env:
-  TOPOS_DOCKER_TAG: ${{ inputs.topos-docker-tag || 'main' }}
+  TOPOS_DOCKER_TAG: ${{ inputs.topos-docker-tag || 'latest' }}
   CONTRACTS_DOCKER_TAG: ${{ inputs.topos-smart-contracts-docker-tag || 'latest' }}
   EXECUTOR_SERVICE_DOCKER_TAG: ${{ inputs.executor-service-docker-tag || 'latest' }}
 


### PR DESCRIPTION
# Description

This PR updates the default docker image used for `topos` from `main` to `latest`, to follow the same principle used for the other stack components.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
