### PR TITLE
feat: add network health check test

### DIFF
--- a/.github/workflows/topos:integration-tests.yml
+++ b/.github/workflows/topos:integration-tests.yml
@@ -90,6 +90,20 @@ jobs:
           echo "ERC20_MESSAGING_CONTRACT_ADDRESS=${ERC20_MESSAGING_CONTRACT_ADDRESS}" >> $GITHUB_ENV
           echo "TOPOS_CORE_PROXY_CONTRACT_ADDRESS=${TOPOS_CORE_PROXY_CONTRACT_ADDRESS}" >> $GITHUB_ENV
 
+      - name: Run network health check tests
+        run: >
+          cd infra &&
+          source .env &&
+          ./tests/test_network_health.sh
+        env:
+          DOCKER_DEFAULT_PLATFORM: linux/amd64
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          TOKEN_DEPLOYER_SALT: ${{ secrets.TOKEN_DEPLOYER_SALT }}
+          TOPOS_CORE_SALT: ${{ secrets.TOPOS_CORE_SALT }}
+          TOPOS_CORE_PROXY_SALT: ${{ secrets.TOPOS_CORE_PROXY_SALT }}
+          ERC20_MESSAGING_SALT: ${{ secrets.ERC20_MESSAGING_SALT }}
+          SUBNET_REGISTRATOR_SALT: ${{ secrets.SUBNET_REGISTRATOR_SALT }}
+
       - name: Run certificates production tests
         run: >
           cd infra &&


### PR DESCRIPTION
# Description

This PR adds a network health check test, which will determine if all the components of the network are in a health condition or not before proceeding to the next tests.

Fixes TP-812

## Additions and Changes

- Added a job to run the `test_network_health` script


## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
