### PR TITLE
feat: use new erc20 e2e-test types

### DIFF
--- a/.github/workflows/frontend:erc20-messaging.yml
+++ b/.github/workflows/frontend:erc20-messaging.yml
@@ -6,6 +6,13 @@ on:
       - main
   workflow_dispatch:
     inputs:
+      e2e-test-type:
+        description: "Type of e2e-tests from dapp-frontend-erc20-messaging"
+        type: choice
+        default: light
+        options:
+        - light
+        - full
       local-erc20-messaging-infra-ref:
         description: "Git ref of local-erc20-messaging-infra"
         required: false
@@ -23,6 +30,7 @@ on:
         required: false
 
 env:
+  E2E_TEST_TYPE: ${{ inputs.e2e-test-type || 'light' }}
   TOPOS_DOCKER_TAG: ${{ inputs.topos-docker-tag || 'latest' }}
   CONTRACTS_DOCKER_TAG: ${{ inputs.topos-smart-contracts-docker-tag || 'latest' }}
   EXECUTOR_SERVICE_DOCKER_TAG: ${{ inputs.executor-service-docker-tag || 'latest' }}
@@ -124,6 +132,7 @@ jobs:
           DOCKER_DEFAULT_PLATFORM: linux/amd64
           CYPRESS_REMOTE_DEBUGGING_PORT: ${{ vars.CYPRESS_REMOTE_DEBUGGING_PORT }}
           PORT: 3001
+          E2E_TEST_TYPE: ${{ env.E2E_TEST_TYPE }}
           AUTH0_AUDIENCE: ${{ secrets.AUTH0_AUDIENCE }}
           AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
           AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
@@ -151,25 +160,25 @@ jobs:
         if: failure()
         run: docker logs incal-sequencer
 
-      - name: Debug TCE boot node
+      - name: Debug topos node 1
         if: failure()
-        run: docker logs topos-node-1 || docker logs infra-tce-boot-1
+        run: docker logs topos-node-1
 
-      - name: Debug TCE peer node 2
+      - name: Debug topos node 2
         if: failure()
-        run: docker logs topos-node-2 || docker logs infra-tce-peer-1
+        run: docker logs topos-node-2
 
-      - name: Debug TCE peer node 3
+      - name: Debug topos node 3
         if: failure()
-        run: docker logs topos-node-3 || docker logs infra-tce-peer-2
+        run: docker logs topos-node-3
 
-      - name: Debug TCE peer node 4
+      - name: Debug topos node 4
         if: failure()
-        run: docker logs topos-node-4 || docker logs infra-tce-peer-3
+        run: docker logs topos-node-4
 
-      - name: Debug TCE infra-peer-4
+      - name: Debug incal node 1
         if: failure()
-        run: docker logs infra-tce-peer-4
+        run: docker logs incal-node-1
 
       - name: Debug executor service
         if: failure()

--- a/.github/workflows/frontend:erc20-messaging.yml
+++ b/.github/workflows/frontend:erc20-messaging.yml
@@ -30,7 +30,7 @@ on:
         required: false
 
 env:
-  E2E_TEST_TYPE: ${{ inputs.e2e-test-type || 'light' }}
+  E2E_TEST_TYPE: ${{ inputs.e2e-test-type }}
   TOPOS_DOCKER_TAG: ${{ inputs.topos-docker-tag || 'latest' }}
   CONTRACTS_DOCKER_TAG: ${{ inputs.topos-smart-contracts-docker-tag || 'latest' }}
   EXECUTOR_SERVICE_DOCKER_TAG: ${{ inputs.executor-service-docker-tag || 'latest' }}


### PR DESCRIPTION
# Description

This PR introduces a new flavor of ERC20Messaging frontend e2e tests: `light` (with the previously only flavor named `full`). This new parameter allows to run lighter ERC20Messaging frontend e2e tests where only the cross-subnet ERC20 transfer is tested (without verifying that all frontend features work as expected).

This so far reduces the e2e-test duration by 2min.

Fixes TOO-411

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
