### PR TITLE
feat: always display executor service logs

### DIFF
--- a/.github/workflows/frontend:erc20-messaging.yml
+++ b/.github/workflows/frontend:erc20-messaging.yml
@@ -181,7 +181,6 @@ jobs:
         run: docker logs incal-node-1
 
       - name: Debug executor service
-        if: failure()
         run: docker logs executor-service
 
       - name: Archive e2e artifacts


### PR DESCRIPTION
# Description

This PR updates the condition for the "Display executor service logs" step so that it is always run. This will help showing how long the Executor Service waits for the cert to be delivered and imported on the receiving subnet.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
